### PR TITLE
delete empty link with private information

### DIFF
--- a/lattice/hx8k.mk
+++ b/lattice/hx8k.mk
@@ -1,1 +1,0 @@
-/home/fabio/dec/adda/fpga/hx8k.mk


### PR DESCRIPTION
FIXME: needs replacing with the missing actual Makefile content.

The private infomation is, that path shows exactly what your login is on your PC "/home/<login>/...".
I'm almost certain this is not what you meant to do, when you ran 

    ln -s ~/dec/adda/fpga/hx8k.mk

recommend try again, except without the -s flag: This will create a hard link, which will be what you likely intended: to git it will just be a normal file, but to you it will be the same file, and changing it at either location will be updating the one actual file (this is how a *hard* link works in unix).